### PR TITLE
Fix typo in Portuguese translation

### DIFF
--- a/po/pt.po
+++ b/po/pt.po
@@ -27,7 +27,7 @@ msgstr "File Shredder"
 #: data/com.github.ADBeveridge.Raider.metainfo.xml:7
 #: src/raider-application.c:110
 msgid "Securely delete your files"
-msgstr "Apague seus archivos de forma segura"
+msgstr "Apague seus arquivos de forma segura"
 
 #: data/com.github.ADBeveridge.Raider.metainfo.xml:9
 msgid ""


### PR DESCRIPTION
While "Archivos" is the Spanish translation of files, Portuguese (Brazilian, at least) uses "arquivos". Since the rest of the file use "arquivos", this PR is to make it uniform.