### PR TITLE
fix: LINGUAS

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,9 +1,9 @@
 es
 fr
-it_IT
+it
 oc
-pt
 pt_BR
+pt
 ru
 sv
 tr


### PR DESCRIPTION
Fixes issue when build failed because `it` was named as `it_IT` in LINGUAS, and also sorts everything alphabetically

#76 introduced this issue