### PR TITLE
raider-window: Add tooltip to main menu

### DIFF
--- a/src/raider-window.blp
+++ b/src/raider-window.blp
@@ -43,6 +43,7 @@ template RaiderWindow : Adw.ApplicationWindow {
       [end]
       Gtk.MenuButton {
         icon-name: "open-menu-symbolic";
+        tooltip-text: _("Main Menu");
         menu-model: primary_menu;
         primary: true;
       }


### PR DESCRIPTION
The HIG recommends the "Main Menu" tooltip for main menus, let's follow that.