### PR TITLE
Update developer ID

### DIFF
--- a/data/com.github.ADBeveridge.Raider.metainfo.xml.in.in
+++ b/data/com.github.ADBeveridge.Raider.metainfo.xml.in.in
@@ -27,7 +27,7 @@
   <update_contact>adgbeveridge@proton.me</update_contact>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Alan Beveridge</developer_name>
-  <developer id="github.com">
+  <developer id="io.github.adgbeveridge">
     <name translatable="no">Alan Beveridge</name>
   </developer>
   <requires>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDs.

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer