### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/com.github.ADBeveridge.Raider.metainfo.xml.in.in
+++ b/data/com.github.ADBeveridge.Raider.metainfo.xml.in.in
@@ -26,9 +26,9 @@
   <url type="translate">https://github.com/ADBeveridge/raider/tree/develop/po</url>
   <update_contact>adgbeveridge@proton.me</update_contact>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Alan Beveridge</developer_name>
+  <developer_name translate="no">Alan Beveridge</developer_name>
   <developer id="io.github.adgbeveridge">
-    <name translatable="no">Alan Beveridge</name>
+    <name translate="no">Alan Beveridge</name>
   </developer>
   <requires>
     <display_length compare="ge">360</display_length>
@@ -53,7 +53,7 @@
   </screenshots>
   <releases>
 		<release version="2.1.0" date="2023-12-1">
-      <description translatable="no">
+      <description translate="no">
         <p>Update visuals for GNOME 45</p>
         <ul>
           <li>Use a flat headerbar</li>
@@ -62,7 +62,7 @@
       </description>
     </release>
     <release version="2.0.0" date="2023-08-15">
-      <description translatable="no">
+      <description translate="no">
         <p>Use custom code for shredding files</p>
         <ul>
           <li>Use custom code in Raider for shredding a file</li>
@@ -71,12 +71,12 @@
       </description>
     </release>
     <release version="1.3.1" date="2022-10-13">
-      <description translatable="no">
+      <description translate="no">
         <p>Fix UI bug when shredding is aborted</p>
       </description>
     </release>
     <release version="1.3.0" date="2022-9-20">
-      <description translatable="no">
+      <description translate="no">
         <p>Updates to help and application</p>
         <ul>
           <li>Add keyboard shortcuts to common actions</li>
@@ -90,7 +90,7 @@
       </description>
     </release>
     <release version="1.2.2" date="2022-8-19">
-      <description translatable="no">
+      <description translate="no">
         <p>Bug fixes and translation updates</p>
         <ul>
           <li>Add Chinese, Turkish, Occitan and Brazilian Portuguese translations</li>
@@ -99,7 +99,7 @@
       </description>
     </release>
     <release version="1.2.1" date="2022-8-10">
-      <description translatable="no">
+      <description translate="no">
         <p>User interface fixes</p>
         <ul>
           <li>Add explanatory message and changed initial view's icon</li>
@@ -108,7 +108,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2022-8-06">
-      <description translatable="no">
+      <description translate="no">
         <p>User interface fixes</p>
         <ul>
           <li>Fix cropping of keyboard focus ring on shred button</li>
@@ -118,7 +118,7 @@
       </description>
     </release>
     <release version="1.1.1" date="2022-8-03">
-      <description translatable="no">
+      <description translate="no">
         <p>Bug fixes and translation updates</p>
         <ul>
           <li>Add the French translation</li>
@@ -130,7 +130,7 @@
       </description>
     </release>
     <release version="1.1.0" date="2022-7-28">
-      <description translatable="no">
+      <description translate="no">
         <p>Minor fixes, including:</p>
         <ul>
           <li>Move the Shred button to the bottom of the window</li>
@@ -140,7 +140,7 @@
       </description>
     </release>
     <release version="1.0.0.alpha1" date="2022-6-30">
-      <description translatable="no">
+      <description translate="no">
         <p>A significant rewite of File Shredder, with a few UI changes changes:</p>
         <ul>
           <li>Add checking so a file cannot be loaded twice</li>
@@ -151,7 +151,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2021-12-30">
-      <description translatable="no">
+      <description translate="no">
         <p>The very first release of File Shredder. It supports progress tracking, and
 	      has a GNOME compliant interface.</p>
       </description>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html