### PR TITLE
appstream: Fix vcs-browser URL

### DIFF
--- a/data/com.github.ADBeveridge.Raider.metainfo.xml.in.in
+++ b/data/com.github.ADBeveridge.Raider.metainfo.xml.in.in
@@ -22,7 +22,7 @@
   <launchable type="desktop-id">com.github.ADBeveridge.Raider.desktop</launchable>
   <url type="homepage">https://apps.gnome.org/Raider</url>
   <url type="bugtracker">https://github.com/ADBeveridge/raider/issues</url>
-  <url type="vcs-browser">https://github.com/ADBeveridge/raider/tree/develop</url>
+  <url type="vcs-browser">https://github.com/ADBeveridge/raider</url>
   <url type="translate">https://github.com/ADBeveridge/raider/tree/develop/po</url>
   <update_contact>adgbeveridge@proton.me</update_contact>
   <!-- developer_name tag deprecated with Appstream 1.0 -->


### PR DESCRIPTION
GNOME tools can't work with a specific branch specified and it's also not needed and not future-proof.