### PR TITLE
Disable 'use-markup' property on file rows

### DIFF
--- a/src/raider-file-row.blp
+++ b/src/raider-file-row.blp
@@ -4,6 +4,7 @@ using Adw 1;
 template $RaiderFileRow : Adw.ActionRow {
   selectable: false;
   activatable: true;
+  use-markup: false;
 
   [suffix]
   Gtk.Box controls {


### PR DESCRIPTION
This fixes filenames containing an ampersand from showing up as empty:

https://github.com/user-attachments/assets/78fde0b8-4d22-4dae-9676-d4f3504199a5

