### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/com.github.ADBeveridge.Raider.desktop.in.in
+++ b/data/com.github.ADBeveridge.Raider.desktop.in.in
@@ -8,5 +8,6 @@ Terminal=false
 Type=Application
 Categories=GTK;Utility;FileTools;Security;
 StartupNotify=true
+DBusActivatable=true
 X-GNOME-UsesNotifications=true
 X-Purism-FormFactor=Workstation;Mobile;

--- a/data/com.github.ADBeveridge.Raider.service.in
+++ b/data/com.github.ADBeveridge.Raider.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.github.ADBeveridge.Raider
+Exec=@bindir@/raider --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -29,4 +29,14 @@ if appstreamcli.found()
   )
 endif
 
+service_conf = configuration_data()
+service_conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+configure_file(
+  input: 'com.github.ADBeveridge.Raider.service.in',
+  output: 'com.github.ADBeveridge.Raider.service',
+  configuration: service_conf,
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1', 'services')
+)
+
 subdir('icons')


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html